### PR TITLE
Fix broken output redirection on Linux

### DIFF
--- a/src/TestCaseGenerator.java
+++ b/src/TestCaseGenerator.java
@@ -33,7 +33,9 @@ public class TestCaseGenerator {
 
 
             Process process;
-            String command = ProblemConfigData.getSolutionRunCommand(i) + '>' + outputPath.toAbsolutePath();
+            String command = ProblemConfigData.getSolutionRunCommand(i);
+            builder.redirectOutput(outputPath.toFile());
+
             if (isWindows) {
                 process = builder.command("cmd", "/c", command).start();
             } else {


### PR DESCRIPTION
Hello!
I tested you code on my Linux machine. The only part that seemed not to work was when it tried to output the solutions to `output*.txt` files, where it simply failed to do so (no error messages, just no output files were created). Here is a small fix that worked on my Linux machine.
I haven't tested this on Windows, but since this fix uses a standard Java method for outputing solutions, I'm confident that this will work on Windows as well.